### PR TITLE
URL Cleanup

### DIFF
--- a/doc/Socket.graphml
+++ b/doc/Socket.graphml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:y="http://www.yworks.com/xml/graphml" xmlns:yed="http://www.yworks.com/xml/yed/3" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd">
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:y="https://www.yworks.com/xml/graphml" xmlns:yed="https://www.yworks.com/xml/yed/3" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns https://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd">
   <!--Created by yEd 3.13-->
   <key for="graphml" id="d0" yfiles.type="resources"/>
   <key for="port" id="d1" yfiles.type="portgraphics"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.org/doc/man/ssl.html (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.org/doc/man/ssl.html) result ConnectTimeoutException).
* http://graphml.graphdrawing.org/xmlns (403) with 2 occurrences could not be migrated:  
   ([https](https://graphml.graphdrawing.org/xmlns) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.yworks.com/xml/graphml (301) with 1 occurrences migrated to:  
  https://www.yworks.com/xml/graphml ([https](https://www.yworks.com/xml/graphml) result 404).
* http://www.yworks.com/xml/yed/3 (301) with 1 occurrences migrated to:  
  https://www.yworks.com/xml/yed/3 ([https](https://www.yworks.com/xml/yed/3) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd with 1 occurrences migrated to:  
  https://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd ([https](https://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences